### PR TITLE
use default target of _blank, override where appropriate

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Then, clone the repo and run `bundle install`.
 
 Now, you can get the site up and running locally by running `jekyll serve`. You can view the running site by going to [http://localhost:4000/rails_tutorial/](http://localhost:4000/rails_tutorial/).
 
+## Caveats
+
+### Links
+The config value `open_links_in_new_tab` in `config.yml` results in all links opening in a new tab. You can override this behavior on individual links by setting the target attribute back to the default value (`_self`) or if you just don't want the thing to work that way, remove that config value or set it to false.
+
 ##Deploying
 
 Because we use custom plugins that Github-pages doesn't support, you must compile the page locally and deploy the contents of the _site directory only to the gh-pages branch using the following steps: 

--- a/_config.yml
+++ b/_config.yml
@@ -20,6 +20,7 @@
 #   line in _config.yml. It will appear in your document head meta (for
 #   Google search results) and in your feed.xml site description.
 baseurl: "/rails_tutorial" # the subpath of your site, e.g. /blog
+open_links_in_new_tab: true
 # url: "" # the base hostname & protocol for your site, e.g. http://example.com
 # twitter_username: jekyllrb
 # github_username:  jekyll

--- a/_includes/tutorial_header.html
+++ b/_includes/tutorial_header.html
@@ -2,7 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <base target="_blank"/>
+    {% if site.open_links_in_new_tab %}
+      <base target="_blank"/>
+    {% endif %}
     <title>B'more on Rails Workshop for Women</title>
     <link href="{{ site.baseurl }}/css/syntax.css" type="text/css" rel="stylesheet"/>
     <link href="{{ site.baseurl }}/css/base.css" type="text/css" rel="stylesheet"/>

--- a/_includes/tutorial_header.html
+++ b/_includes/tutorial_header.html
@@ -2,9 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
+    <base target="_blank"/>
     <title>B'more on Rails Workshop for Women</title>
-   <link href="{{ site.baseurl }}/css/syntax.css" type="text/css" rel="stylesheet"/>
-   <link href="{{ site.baseurl }}/css/base.css" type="text/css" rel="stylesheet"/>
+    <link href="{{ site.baseurl }}/css/syntax.css" type="text/css" rel="stylesheet"/>
+    <link href="{{ site.baseurl }}/css/base.css" type="text/css" rel="stylesheet"/>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
     <script src="{{ site.baseurl }}/js/tutorial_nav.js"></script>
   </head>

--- a/_includes/tutorial_navigation.html
+++ b/_includes/tutorial_navigation.html
@@ -3,7 +3,7 @@
   <ul id="menu-list">
     {% for chapter in site.chapters %}
      <li>
-      <a href="{{ site.baseurl }}{{chapter.url}}">
+      <a href="{{ site.baseurl }}{{chapter.url}}" target="_self">
         {{ chapter.number }} {{ chapter.title }}
        </a>
      </li>  
@@ -11,7 +11,7 @@
    </ul>
 
   <div class="menu" data-toggle="#menu-list">
-    <a href="#menu" class="hamburger">
+    <a href="#menu" class="hamburger" target="_self">
       <div class="hamburger-icon"> &#9776</div>
       <div class="menu-title">Chapter {{page.number}} -- {{ page.title }}</div>
     </a>

--- a/index.md
+++ b/index.md
@@ -7,7 +7,7 @@ layout: rails_tutorial
 
 {% for chapter in site.chapters %}
   <div class="chapter">
-    <a href="{{ site.baseurl }}{{chapter.url}}">
+    <a href="{{ site.baseurl }}{{chapter.url}}" target="_self">
       {{ chapter.number }} {{ chapter.title }}
     </a>
   </div>


### PR DESCRIPTION
Fixes #22. We'll have to be careful when adding new nav links to include a target of "_self" but I think this solution is preferable to manually adding target="_blank" to all other links (which there are more of).