### PR TITLE
Lists in step containers without highlight blocks are borked

### DIFF
--- a/_scss/tutorial/list.scss
+++ b/_scss/tutorial/list.scss
@@ -36,12 +36,6 @@
 }
 
 @media (min-width: 480px) {
-  .steps {
-    .list {
-      margin-left: auto;
-      margin-right: auto;
-    }
-  }
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
Fixes #35 

I had actually fixed this in `bugfix/syntax-highlighting` but then reverted it cuz i thought centering was intended behavior haha.