### PR TITLE
Mention in README that trailing slash on URLs is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Before you get started, make sure you have Ruby 2.x installed locally.
 
 Then, clone the repo and run `bundle install`.
 
-Now, you can get the site up and running locally by running `jekyll serve`. You can view the running site by going to [http://localhost:4000/rails_tutorial/](http://localhost:4000/rails_tutorial/).
+Now, you can get the site up and running locally by running `jekyll serve`. You can view the running site by going to [http://localhost:4000/rails_tutorial/](http://localhost:4000/rails_tutorial/). (Note that the trailing slash is **not** optional.)
 
 ## Caveats
 


### PR DESCRIPTION
Why:
* I spent much more time than I'd like to admit wondering why I couldn't
see the page and was getting "ERROR '/rails_tutorial' not found."

This change addresses the need by:
* Adding a brief note to the README.