### PR TITLE
Switch the start commands between win7 and win81

### DIFF
--- a/_installation/win7_sp1.md
+++ b/_installation/win7_sp1.md
@@ -97,9 +97,9 @@ WARNING: By following these instructions to manually update, you will be redirec
 
 **Once the installer is finished:**
 
-1. Swipe right and click on Start Menu
+1. Click on Start
 
-2. In the Start Menu, click or tap on All Apps (mouse over on the bottom left hand corner until your see the down arrow)
+2. Click on All Programs
 
 3. Scroll down to Ruby 2.3.1-p112
 

--- a/_installation/win8.md
+++ b/_installation/win8.md
@@ -128,9 +128,9 @@ Click on [Windows 8.1](https://support.microsoft.com/en-us/help/15356){:target='
 
 **Once the installer is finished:**
 
-1. Click on Start
+1. Swipe right and click on Start Menu
 
-2. Click All Programs
+2. In the Start Menu, swipe up or click/tap on All Apps (mouse over on the bottom left hand corner until your see the down arrow).
 
 3. Scroll down to Ruby 2.3.1-p112
 


### PR DESCRIPTION
Reviewing the installation instructions for win7 and win81, saw the commands were switched in the files.  These changes makes them correct for the OS.