### PR TITLE
Typo in chapter_03.md when running Books.all

### DIFF
--- a/_chapters/chapter_03.md
+++ b/_chapters/chapter_03.md
@@ -617,7 +617,7 @@ You might remember reading about arrays in the [Ruby in 100 minutes](http://tuto
   1.  Run the following code:
 
       ```ruby
-      books = Books.all
+      books = Book.all
       ```
 
       You now have a `books` variable that's been assigned all the books in your application's database. `books` can be thought of as a Ruby Array.


### PR DESCRIPTION
I changed the line `books = Books.all` to `books = Book.all` because the database was not recognizing the class Books. It unfortunately took me 30 minutes to figure out the class is Book and wanted to save everyone time if they typed in the wrong thing.