### PR TITLE
Add rake task to automate deploy process

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,21 +1,8 @@
 source "https://rubygems.org"
 
-# Hello! This is where you manage which Jekyll version is used to run.
-# When you want to use a different version, change it below, save the
-# file and run `bundle install`. Run Jekyll with `bundle exec`, like so:
-#
-#     bundle exec jekyll serve
-#
-# This will help ensure the proper Jekyll version is running.
-# Happy Jekylling!
 gem "jekyll", "3.3.0"
-
-# This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minima", "~> 2.0"
-
-# If you want to use GitHub Pages, remove the "gem "jekyll"" above and
-# uncomment the line below. To upgrade, run `bundle update github-pages`.
-# gem "github-pages", group: :jekyll_plugins
+gem "rake", "~> 12.0.0"
 
 # If you have any plugins, put them here!
 group :jekyll_plugins do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,6 +33,7 @@ GEM
     pathutil (0.14.0)
       forwardable-extended (~> 2.6)
     public_suffix (2.0.3)
+    rake (12.0.0)
     rb-fsevent (0.9.8)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
@@ -47,6 +48,7 @@ DEPENDENCIES
   jekyll (= 3.3.0)
   jekyll-feed (~> 0.6)
   minima (~> 2.0)
+  rake (~> 12.0.0)
 
 BUNDLED WITH
    1.13.6

--- a/README.md
+++ b/README.md
@@ -21,18 +21,21 @@ The config value `open_links_in_new_tab` in `config.yml` results in all links op
 
 ##Deploying
 
-Because we use custom plugins that Github-pages doesn't support, you must compile the page locally and deploy the contents of the _site directory only to the gh-pages branch using the following steps: 
+First, checkout master and pull the latest changes.
 
-Deploying is a little dangerous with the jekyll site because there is no versioning on the gh-pages branch. So please be super thoughtful before pushing changes. 
+```sh
+git checkout master
+git pull origin master
+```
 
-1. Delete your local copy of the gh-pages branch if you already have one. `git branch -D gh-pages`
-1. `git checkout master`
-1. `git pull origin master`
-1. `git checkout -b gh-pages`
-1. `jekyll build`
-1. `rm -rf _config.yml _layouts _scss about.md index.md _chapters _includes _plugins css js Gemfile.lock Gemfile _installation/ README.md assets/`
-1. `mv _site/* .`
-1. `rm -rf _site/`
-1. `git add .`
-1. `git commit -m "Your commit message"`
-1. `git push origin gh-pages -f`
+Then, run `rake prepare_deploy`.
+
+```sh
+rake prepare_deploy
+```
+
+When the task finishes, you'll be on the `gh-pages` branch. There will be a new commit for the changes you're deploying. If everything looks good, push the changes.
+
+```sh
+git push origin gh-pages
+```

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,8 @@
+require './lib/deployer'
+
+desc "Prepare the current branch for deployment"
+task :prepare_deploy do
+  deploy_sha = `git rev-parse --verify HEAD`
+
+  Deployer.prepare_deploy(deploy_sha: deploy_sha)
+end

--- a/_config.yml
+++ b/_config.yml
@@ -43,3 +43,6 @@ gems:
 exclude:
   - Gemfile
   - Gemfile.lock
+  - README.md
+  - Rakefile
+  - lib

--- a/lib/deployer.rb
+++ b/lib/deployer.rb
@@ -1,0 +1,59 @@
+require "rake/file_utils"
+
+class Deployer
+  include FileUtils
+
+  attr_reader :build_dir, :deploy_branch, :deploy_sha
+
+  def self.prepare_deploy(options={})
+    self.new(options).prepare_deploy
+  end
+
+  def initialize(options={})
+    @build_dir = options.fetch(:build_dir, "_site")
+    @deploy_branch = options.fetch(:deploy_branch, "gh-pages")
+    @deploy_sha = options.fetch(:deploy_sha)
+  end
+
+  def prepare_deploy
+    build
+    prepare_deploy_branch
+    promote_build
+    show_message
+  end
+
+  private
+
+  def build
+    sh "jekyll build --destination #{build_dir}"
+  end
+
+  def prepare_deploy_branch
+    sh "git checkout #{deploy_branch}"
+    sh "rm -rf .sass-cache"
+    sh "git rm -rf ."
+  end
+
+  def promote_build
+    sh "mv #{build_dir}/* ."
+    sh "rm -rf #{build_dir}"
+    sh "git add ."
+    sh "git commit -m 'Deploy #{deploy_sha}'"
+  end
+
+  def show_message
+    message = <<~MESSAGE
+      Hi, #{username}!
+      You're now on the #{deploy_branch} branch, and the changes you want to deploy have been committed.
+      Take a look at the changes. If everything looks good, you can deploy the changes by pushing this branch.
+    MESSAGE
+
+    puts "*" * 100
+    puts message
+    puts "*" * 100
+  end
+
+  def username
+    `git config user.name`.strip
+  end
+end


### PR DESCRIPTION
This is the first step to automating deploys.

In this PR, I added a rake task called `prepare_deploy`. It builds the site from the branch where it's run. In most cases, `prepare_deploy` should be run from master. Then, it takes the new site contents and adds a new deploy commit to the gh-pages branch. When it finishes, you'll be on the gh-pages branch. You can review the changes and decide whether you want to push them or not.

I played around with it on my fork. You can see what the commit history looks like [here](https://github.com/alimi/rails_tutorial/commits/gh-pages). 